### PR TITLE
Add install instructions for Coq-HoTT

### DIFF
--- a/Coq-Playground/README.md
+++ b/Coq-Playground/README.md
@@ -1,0 +1,68 @@
+# Playing with Coq-HoTT in the browser
+
+If you'd rather avoid installing Coq locally, you can run Coq with the 
+HoTT library directly [in your browser](https://x80.org/rhino-hott/). 
+The document there can be modified and run interactively, so that should
+be enough for doing the exercises.
+
+# Installation instructions for Coq
+
+The Coq HoTT library requires a bit of a customized installation of Coq.
+You can download pre-built packages for various platforms by following the links here:
+
+  - For Windows: [32 bits]() and [64 bits]()
+  - For [MacOS]()
+  - For Linux distributions: a [snap]() package is available.
+
+These packages come with an Integrated Development Environment, CoqIDE for short,
+which needs to be configured to call a specific Coq version. To do so, simply go 
+to the `Preferences` menu, under `Edit`, then the `External` tab, and set
+`coqidetop` to:
+    
+  - On MacOS: `/Applications/Coq_Platform_2021.02.0-hott.app/Contents/Resources/bin/hoqidetop` 
+  - On Windows: `C:\Coq\bin\hoqidetop`
+  - On Linux: `/snap/bin/coq.hoqidetop` or `~/.opam/_coq-platform_.2021-02.0-hott/bin/hoqidetop` (for a local `opam` installation of the platform)
+
+To test your installation, simply run the [test](TestHoTT.v) file available in this repository,
+by opening the file or copy-pasting its contents in a buffer, then using the forward navigation 
+buttons to evaluate it.
+
+## Alternative IDEs
+
+### Emacs
+
+If you would rather use Emacs, then you should install [Proof-General](https://proofgeneral.github.io/) 
+(and the excellent `company-coq` mode) through `melpa` (look at Proof-General's page for instructions). 
+Then you can point to a specific `coqtop` using `M-x set-variable coq-prog-name` and enter the 
+path to `hoqtop` (note, without `ide`).
+
+### VSCode
+
+Coq also has a language server protocol implementation so it can be used with [VSCode](https://code.visualstudio.com/). To use it, install VSCode and the [VSCoq](https://marketplace.visualstudio.com/items?itemName=maximedenes.vscoq) extension. Make a workspace for the school and set the settings as:
+
+    "Coqtop: bin path"
+         /Applications/Coq_Platform_2021.02.0.app/Contents/Resources/bin" 
+         (depending on your platform installation)
+
+    "Coqtop: Coqidetop exe"
+         "hoqidetop"
+    
+    "Coqtop: Coqtop exe"
+         "hoqtop"
+    
+Alternatively, you can edit the workspace file's `settings` section:
+
+    "coqtop.binPath": "/Applications/Coq_Platform_2021.02.0.app/Contents/Resources/bin",
+    "coqtop.coqidetopExe": "hoqidetop",
+    "coqtop.coqtopExe": "hoqtop",
+
+## Installation from `opam`
+
+If you already are an [`opam`](http://opam.ocaml.org) user, then you can simply install `coq` 
+and the `coq-hott` package, available from the `extra-dev` repository of Coq, using:
+
+     # opam repo add coq-extra-dev http://coq.inria.fr/opam/extra-dev
+     # opam install coq.8.13.1 coq-hott.8.13.dev
+
+You the need to adjust for the path of `hoqidetop` in the interface you choose, which you
+can find after successful installation using `which hoqidetop`.

--- a/Coq-Playground/README.md
+++ b/Coq-Playground/README.md
@@ -7,25 +7,25 @@ be enough for doing the exercises.
 
 # Installation instructions for Coq
 
-The Coq HoTT library requires a bit of a customized installation of Coq.
-You can download pre-built packages for various platforms by following the links here:
+To install Coq along with the Coq HoTT library, you can use pre-built packages 
+for various platforms:
 
-  - For Windows: [32 bits]() and [64 bits]()
-  - For [MacOS]()
-  - For Linux distributions: a [snap]() package is available.
+  - For Windows: [32 bits](https://github.com/HoTT/EPIT-2020/releases/download/v0.1/Windows.installer.32.bits.zip) and [64 bits](https://github.com/HoTT/EPIT-2020/releases/download/v0.1/Windows.installer.64.bits.zip)
+  - For [MacOS](https://github.com/HoTT/EPIT-2020/releases/download/v0.1/Macos.installer.zip)
+  
+    Note: after copying the application to /Applications, you may have to right-click on it 
+    and "Open" it explicitly to bypass MacOS's safeguard about applications downloaded for the web.
+  - For Linux distributions: a [snap](https://github.com/HoTT/EPIT-2020/releases/download/v0.1/Snap.package.zip) package is available.
 
 These packages come with an Integrated Development Environment, CoqIDE for short,
-which needs to be configured to call a specific Coq version. To do so, simply go 
-to the `Preferences` menu, under `Edit`, then the `External` tab, and set
-`coqidetop` to:
-    
-  - On MacOS: `/Applications/Coq_Platform_2021.02.0-hott.app/Contents/Resources/bin/hoqidetop` 
-  - On Windows: `C:\Coq\bin\hoqidetop`
-  - On Linux: `/snap/bin/coq.hoqidetop` or `~/.opam/_coq-platform_.2021-02.0-hott/bin/hoqidetop` (for a local `opam` installation of the platform)
+which needs to be configured to call Coq with specific arguments. This can be done
+simply by putting the following [_CoqProject](_CoqProject) file at the root of your
+project, so that interfaces (CoqIDE, Emacs or VSCoq) can pick it up.
+
+### Testing
 
 To test your installation, simply run the [test](TestHoTT.v) file available in this repository,
-by opening the file or copy-pasting its contents in a buffer, then using the forward navigation 
-buttons to evaluate it.
+by copying it *in the same folder as _CoqProject*, opening it in `CoqIDE`, then using the forward navigation buttons to evaluate it.
 
 ## Alternative IDEs
 
@@ -33,29 +33,19 @@ buttons to evaluate it.
 
 If you would rather use Emacs, then you should install [Proof-General](https://proofgeneral.github.io/) 
 (and the excellent `company-coq` mode) through `melpa` (look at Proof-General's page for instructions). 
-Then you can point to a specific `coqtop` using `M-x set-variable coq-prog-name` and enter the 
-path to `hoqtop` (note, without `ide`).
+If you want to customize the arguments yourself, you can use `M-x set-variable coq-prog-args` and enter 
+the list `("-noinit" "-indices-matter")`. 
 
 ### VSCode
 
-Coq also has a language server protocol implementation so it can be used with [VSCode](https://code.visualstudio.com/). To use it, install VSCode and the [VSCoq](https://marketplace.visualstudio.com/items?itemName=maximedenes.vscoq) extension. Make a workspace for the school and set the settings as:
+Coq also has a language server protocol implementation so it can be used with [VSCode](https://code.visualstudio.com/). To use it, install VSCode and the [VSCoq](https://marketplace.visualstudio.com/items?itemName=maximedenes.vscoq) extension. Clone this repository or create a new folder for the school and create a workspace 
+for it (`Add folder to workspace...` and then `Save workspace as...`). 
+Then you can either put  the `_CoqProject` file at the root of this workspace and open Coq files in the
+workspace *or* set the arguments to `coq` explicitely by going to `Settings`, `Workspace`, search for `Coqtop: args`, select `edit in settings.json` and enter:
 
-    "Coqtop: bin path"
-         /Applications/Coq_Platform_2021.02.0.app/Contents/Resources/bin" 
-         (depending on your platform installation)
-
-    "Coqtop: Coqidetop exe"
-         "hoqidetop"
-    
-    "Coqtop: Coqtop exe"
-         "hoqtop"
-    
-Alternatively, you can edit the workspace file's `settings` section:
-
-    "coqtop.binPath": "/Applications/Coq_Platform_2021.02.0.app/Contents/Resources/bin",
-    "coqtop.coqidetopExe": "hoqidetop",
-    "coqtop.coqtopExe": "hoqtop",
-
+     "coqtop.args": [
+          "-noinit", "-indices-matter"
+     ]
 ## Installation from `opam`
 
 If you already are an [`opam`](http://opam.ocaml.org) user, then you can simply install `coq` 
@@ -64,5 +54,4 @@ and the `coq-hott` package, available from the `extra-dev` repository of Coq, us
      # opam repo add coq-extra-dev http://coq.inria.fr/opam/extra-dev
      # opam install coq.8.13.1 coq-hott.8.13.dev
 
-You the need to adjust for the path of `hoqidetop` in the interface you choose, which you
-can find after successful installation using `which hoqidetop`.
+The same adjustment of arguments needs to be done in your choice of interface.

--- a/Coq-Playground/TestHoTT.v
+++ b/Coq-Playground/TestHoTT.v
@@ -1,0 +1,11 @@
+From HoTT Require Import HoTT.
+
+Check Contr.
+Print Contr.
+
+Goal forall x : nat, Contr (x = x).
+Proof.
+  intros x. exists idpath.
+Abort.
+
+Print isequiv_equiv_path.

--- a/Coq-Playground/_CoqProject
+++ b/Coq-Playground/_CoqProject
@@ -1,0 +1,2 @@
+-arg -noinit
+-arg -indices-matter

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Here is the day by day program, the detailed content and timing  of each lecture
 * Day 2. 
   + Bas Spitters: The Coq-HoTT library
   + Exercise session (with Discord)
-  + Prerequisite: have Coq installed per the [instructions](Coq-Playground/README.md)
+  + Prerequisite: check that you can run Coq with the HoTT library,
+    following the [instructions](Coq-Playground/README.md)
 
 * Day 3. 
    + Christian Sattler : Models of Homotopy Type Theory


### PR DESCRIPTION
Thanks to the help of @gares and @MSoegtropIMC and @Alizter we have ready-to-use packages for Coq + HoTT on common platforms now.